### PR TITLE
Added missing primary_key flag to incomebenefits

### DIFF
--- a/enrollment.view.lkml
+++ b/enrollment.view.lkml
@@ -408,6 +408,131 @@ view: enrollment {
     sql: ${TABLE}.VAMCStation ;;
   }
 
+  dimension: living_situation {
+    type: string
+    sql: ${TABLE}.LivingSituation ;;
+  }
+
+  dimension: length_of_stay {
+    type: string
+    sql: ${TABLE}.LengthOfStay ;;
+  }
+
+  dimension: los_under_threshold {
+    type: string
+    sql: ${TABLE}.LOSUnderThreshold ;;
+  }
+
+  dimension: previous_street_essh {
+    type: string
+    sql: ${TABLE}.PreviousStreetESSH ;;
+  }
+
+  dimension: move_in_date {
+    type: string
+    sql: ${TABLE}.MoveInDate ;;
+  }
+
+  dimension: eligible_for_rhy {
+    type: string
+    sql: ${TABLE}.EligibleForRHY ;;
+  }
+
+  dimension: runaway_youth {
+    type: string
+    sql: ${TABLE}.RunawayYouth ;;
+  }
+
+  dimension: urgen_referral {
+    type: string
+    sql: ${TABLE}.UrgentReferral ;;
+  }
+
+  dimension: time_to_housing_loss {
+    type: string
+    sql: ${TABLE}.TimeToHousingLoss ;;
+  }
+
+  dimension: zero_income {
+    type: string
+    sql: ${TABLE}.ZeroIncome ;;
+  }
+
+  dimension: annual_percent_ami {
+    type: string
+    sql: ${TABLE}.AnnualPercentAMI ;;
+  }
+
+  dimension: financial_change {
+    type: string
+    sql: ${TABLE}.FinancialChange ;;
+  }
+
+  dimension: household_change {
+    type: string
+    sql: ${TABLE}.HouseholdChange ;;
+  }
+
+  dimension: eviction_history {
+    type: string
+    sql: ${TABLE}.EvictionHistory ;;
+  }
+
+  dimension: subsidy_at_risk {
+    type: string
+    sql: ${TABLE}.SubsidyAtRisk ;;
+  }
+
+  dimension: literal_homeless_history {
+    type: string
+    sql: ${TABLE}.LiteralHomelessHistory ;;
+  }
+
+  dimension: disabled_hoh {
+    type: string
+    sql: ${TABLE}.DisabledHoH ;;
+  }
+
+  dimension: criminal_record {
+    type: string
+    sql: ${TABLE}.CriminalRecord ;;
+  }
+
+  dimension: sex_offender {
+    type: string
+    sql: ${TABLE}.SexOffender ;;
+  }
+
+  dimension: dependent_under_6 {
+    type: string
+    sql: ${TABLE}.DependentUnder6 ;;
+  }
+
+  dimension: single_parent {
+    type: string
+    sql: ${TABLE}.SingleParent ;;
+  }
+
+  dimension: hh5_plus {
+    type: string
+    sql: ${TABLE}.HH5Plus ;;
+  }
+
+  dimension: iraq_afghanistan {
+    type: string
+    sql: ${TABLE}.IraqAfghanistan ;;
+  }
+
+  dimension: fem_vet {
+    type: string
+    sql: ${TABLE}.FemVet ;;
+  }
+
+  dimension: threshold_score {
+    type: string
+    sql: ${TABLE}.ThresholdScore ;;
+  }
+
   dimension_group: date_created {
     type: time
     sql: ${TABLE}.DateCreated ;;

--- a/exit.view.lkml
+++ b/exit.view.lkml
@@ -143,6 +143,146 @@ view: exit {
     sql: ${TABLE}.WrittenAftercarePlan ;;
   }
 
+  dimension: exchange_for_sex {
+    type: string
+    sql: ${TABLE}.ExchangeForSex ;;
+  }
+
+  dimension: exchange_for_sex_past_three_months {
+    type: string
+    sql: ${TABLE}.ExchangeForSexPastThreeMonths ;;
+  }
+
+  dimension: count_of_exchange_for_sex {
+    type: string
+    sql: ${TABLE}.CountOfExchangeForSex ;;
+  }
+
+  dimension: asked_or_forced_to_exchange_for_sex {
+    type: string
+    sql: ${TABLE}.AskedOrForcedToExchangeForSex ;;
+  }
+
+  dimension: asked_or_forced_to_exchange_for_sex_past_three_months {
+    type: string
+    sql: ${TABLE}.AskedOrForcedToExchangeForSexPastThreeMonths ;;
+  }
+
+  dimension: workplace_violence_threats {
+    type: string
+    sql: ${TABLE}.WorkPlaceViolenceThreats ;;
+  }
+
+  dimension: workplace_promise_difference {
+    type: string
+    sql: ${TABLE}.WorkplacePromiseDifference ;;
+  }
+
+  dimension: coerced_to_continue_work {
+    type: string
+    sql: ${TABLE}.CoercedToContinueWork ;;
+  }
+
+  dimension: labor_exploit_past_three_months {
+    type: string
+    sql: ${TABLE}.LaborExploitPastThreeMonths ;;
+  }
+
+  dimension: counseling_received {
+    type: string
+    sql: ${TABLE}.CounselingReceived ;;
+  }
+
+  dimension: individual_counseling {
+    type: string
+    sql: ${TABLE}.IndividualCounseling ;;
+  }
+
+  dimension: family_counseling {
+    type: string
+    sql: ${TABLE}.FamilyCounseling ;;
+  }
+
+  dimension: group_counseling {
+    type: string
+    sql: ${TABLE}.GroupCounseling ;;
+  }
+
+  dimension: session_count_at_exit {
+    type: string
+    sql: ${TABLE}.SessionCountAtExit ;;
+  }
+
+  dimension: post_exit_counseling_plan {
+    type: string
+    sql: ${TABLE}.PostExitCounselingPlan ;;
+  }
+
+  dimension: sessions_in_plan {
+    type: string
+    sql: ${TABLE}.SessionsInPlan ;;
+  }
+
+  dimension: destination_safe_client {
+    type: string
+    sql: ${TABLE}.DestinationSafeClient ;;
+  }
+
+  dimension: destination_safe_worker {
+    type: string
+    sql: ${TABLE}.DestinationSafeWorker ;;
+  }
+
+  dimension: pos_adult_connections {
+    type: string
+    sql: ${TABLE}.PosAdultConnections ;;
+  }
+
+  dimension: pos_peer_connections {
+    type: string
+    sql: ${TABLE}.PosPeerConnections ;;
+  }
+
+  dimension: pos_community_connections {
+    type: string
+    sql: ${TABLE}.PosCommunityConnections ;;
+  }
+
+  dimension: aftercare_date {
+    type: string
+    sql: ${TABLE}.AftercareDate ;;
+  }
+
+  dimension: aftercare_provided {
+    type: string
+    sql: ${TABLE}.AftercareProvided ;;
+  }
+
+  dimension: email_social_media {
+    type: string
+    sql: ${TABLE}.EmailSocialMedia ;;
+  }
+
+  dimension: telephone {
+    type: string
+    sql: ${TABLE}.Telephone ;;
+  }
+
+  dimension: in_person_individual {
+    type: string
+    sql: ${TABLE}.InPersonIndividual ;;
+  }
+
+  dimension: in_person_group {
+    type: string
+    sql: ${TABLE}.InPersonGroup ;;
+  }
+
+  dimension: cm_exit_reason {
+    type: string
+    sql: ${TABLE}.CMExitReason ;;
+  }
+
   measure: count {
     type: count
     drill_fields: [exit_id, export.export_id, export.source_name, export.software_name]

--- a/incomebenefits.view.lkml
+++ b/incomebenefits.view.lkml
@@ -36,6 +36,11 @@ view: incomebenefits {
     sql: ${TABLE}.COBRA ;;
   }
 
+  dimension: connection_with_soar {
+    type: string
+    sql: ${TABLE}.ConnectionWithSOAR ;;
+  }
+
   dimension: data_collection_stage {
     type: string
     sql: ${TABLE}.DataCollectionStage ;;
@@ -103,6 +108,11 @@ view: incomebenefits {
     sql: ${TABLE}.IncomeFromAnySource ;;
   }
 
+  dimension: indian_health_services {
+    type: string
+    sql: ${TABLE}.IndianHealthServices ;;
+  }
+
   dimension: information_date {
     type: string
     sql: ${TABLE}.InformationDate ;;
@@ -141,6 +151,11 @@ view: incomebenefits {
   dimension: no_hivaidsassistance_reason {
     type: string
     sql: ${TABLE}.NoHIVAIDSAssistanceReason ;;
+  }
+
+  dimension: no_indian_health_services_reason {
+    type: string
+    sql: ${TABLE}.NoIndianHealthServicesReason ;;
   }
 
   dimension: no_medicaid_reason {
@@ -196,6 +211,16 @@ view: incomebenefits {
   dimension: other_income_source_identify {
     type: string
     sql: ${TABLE}.OtherIncomeSourceIdentify ;;
+  }
+
+  dimension: other_insurance {
+    type: string
+    sql: ${TABLE}.OtherInsurance ;;
+  }
+
+  dimension: other_insurance_identify {
+    type: string
+    sql: ${TABLE}.OtherInsuranceIdentify ;;
   }
 
   dimension: other_tanf {

--- a/incomebenefits.view.lkml
+++ b/incomebenefits.view.lkml
@@ -93,6 +93,7 @@ view: incomebenefits {
   }
 
   dimension: income_benefits_id {
+    primary_key: yes
     type: string
     sql: ${TABLE}.IncomeBenefitsID ;;
   }


### PR DESCRIPTION
Apparently measures aren't available in explores without the primary_key flag, which was missing from the incomebenefits view. Added that in, and the count measure appears correctly now.